### PR TITLE
Call Darker in-process, not as a subprocess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ These features will be included in the next release:
 
 Added
 -----
+- Import and call Darker in-process instead of as a subprocess.
 
 Fixed
 -----


### PR DESCRIPTION
This improves performance significantly since overhead from Python startup and module imports is eliminated.

For example, on my laptop, this change reduced the duration of this from 8.9 s to 0.6 s (when run with Darker 1.2.0 on its own code base):
```bash
cd darker
rm -rf .pytest_cache
time pytest -c /dev/null --darker --ignore=src/darker/tests
```