### PR TITLE
Require pytest >= 5.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Added
 
 Fixed
 -----
+- Added missing dependency on ``pytest>=5.4``. This is the minimum version which has the
+  plugin API we're building on.
+
 
 0.0.1_ / 2020-08-06
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ url = https://github.com/akaihola/pytest_darker
 py_modules =
     pytest_darker
 install_requires =
-    darker >= 1.1.0
+    darker>=1.1.0
+    pytest>=5.4
     typing-extensions ; python_version < "3.8"
 python_requires = >=3.6
 # From https://pypi.org/project/setuptools-scm/:


### PR DESCRIPTION
This is the minimum version which has the plugin API we're building on.