### PR TITLE
Limit to Pytest<7 until incompatibility fixed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Fixed
 Added
 -----
 - Import and call Darker in-process instead of as a subprocess.
-- Limit Pytest to version <8 until the incompatibility has been fixed.
+- Limit Pytest to version <7 until the incompatibility has been fixed.
 
 
 0.1.2_ / 2020-08-16

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ py_modules =
     pytest_darker
 install_requires =
     darker >= 1.1.0
-    pytest>=6.0.1,<8
+    pytest>=6.0.1,<7
     typing-extensions ; python_version < "3.8"
 python_requires = >=3.6
 # From https://pypi.org/project/setuptools-scm/:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py36,py37,py38
 
 [testenv]
 deps =
-  pytest>=6.0.1,<8
+  pytest>=6.0.1,<7
   pytest-black
   pytest-isort
   pytest-mypy


### PR DESCRIPTION
```bash
$ pytest --darker -Werror
```
```python
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.12, pytest-7.0.1, pluggy-1.4.0
rootdir: /home/akaihola/prg/darker, configfile: pytest.ini
plugins: kwparametrize-0.0.3, darkgraylib-0.0.1, pytest_darker-0.1.3
collected 0 items / 1 error                                                                                                                                                                                       

===================================================================================================== ERRORS ======================================================================================================
__________________________________________________________________________________________ ERROR collecting test session __________________________________________________________________________________________
../../.virtualenvs/darker/lib/python3.10/site-packages/_pytest/nodes.py:140: in _create
    return super().__call__(*k, **kw)
E   TypeError: DarkerItem.__init__() got an unexpected keyword argument 'path'

During handling of the above exception, another exception occurred:
../../.virtualenvs/darker/lib/python3.10/site-packages/pluggy/_hooks.py:501: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
../../.virtualenvs/darker/lib/python3.10/site-packages/pluggy/_manager.py:119: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
../../.virtualenvs/darker/lib/python3.10/site-packages/pytest_darker.py:104: in pytest_collect_file
    return DarkerItem.from_parent(parent, fspath=path)
../../.virtualenvs/darker/lib/python3.10/site-packages/pytest_darker.py:39: in from_parent
    return cast(DarkerItem, super().from_parent(parent=parent, fspath=fspath, **kw))
../../.virtualenvs/darker/lib/python3.10/site-packages/_pytest/nodes.py:633: in from_parent
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)
../../.virtualenvs/darker/lib/python3.10/site-packages/_pytest/nodes.py:264: in from_parent
    return cls._create(parent=parent, **kw)
../../.virtualenvs/darker/lib/python3.10/site-packages/_pytest/nodes.py:146: in _create
    warnings.warn(
E   pytest.PytestDeprecationWarning: <class 'pytest_darker.DarkerItem'> is not using a cooperative constructor and only takes {'parent', 'fspath'}.
E   See https://docs.pytest.org/en/stable/deprecations.html#constructors-of-custom-pytest-node-subclasses-should-take-kwargs for more details.
============================================================================================= short test summary info =============================================================================================
ERROR  - pytest.PytestDeprecationWarning: <class 'pytest_darker.DarkerItem'> is not using a cooperative constructor and only takes {'parent', 'fspath'}.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================ 1 error in 0.10s =================================================================================================
```